### PR TITLE
APIs + Components init caching + version bump

### DIFF
--- a/includes/blocks-support.php
+++ b/includes/blocks-support.php
@@ -106,7 +106,9 @@ final class Monri_WC_Blocks_Support extends AbstractPaymentMethodType {
 		}
 
 		// mostly for components config for now
-		$data = array_merge( $data, $this->gateway->prepare_blocks_data() );
+		if (is_checkout()) {
+            $data = array_merge( $data, $this->gateway->prepare_blocks_data() );
+        }
 
 		// @todo not aware of bottom limit
 

--- a/includes/gateway-adapter-webpay-form.php
+++ b/includes/gateway-adapter-webpay-form.php
@@ -25,6 +25,8 @@ class Monri_WC_Gateway_Adapter_Webpay_Form {
 
 		add_action( 'woocommerce_receipt_' . $this->payment->id, [ $this, 'process_redirect' ] );
 		add_action( 'woocommerce_before_thankyou', [ $this, 'process_return' ] );
+        add_action( 'woocommerce_order_status_changed', [ $this, 'process_capture' ], null, 4 );
+        add_action( 'woocommerce_order_status_changed', [ $this, 'process_void' ], null, 4 );
 
 		// load installments fee logic if installments enabled
 		if ( $this->payment->get_option( 'paying_in_installments' ) ) {
@@ -150,6 +152,8 @@ class Monri_WC_Gateway_Adapter_Webpay_Form {
 			'callback_url_override' => add_query_arg( 'wc-api', 'monri_callback', get_home_url() )
 		);
 
+        $order->add_meta_data('transaction_type', $args['transaction_type']);
+        $order->save();
 		$number_of_installments = $order->get_meta('monri_installments' ) ? (int) $order->get_meta('monri_installments' ) : 1;
 		$number_of_installments = min( max( $number_of_installments, 1 ), 24 );
 		if ( $number_of_installments > 1 ) {
@@ -217,7 +221,6 @@ class Monri_WC_Gateway_Adapter_Webpay_Form {
 		if ( ! $order || $order->get_payment_method() !== $this->payment->id ) {
 			return;
 		}
-
 		Monri_WC_Logger::log( "Response data: " . sanitize_textarea_field( print_r( $_GET, true ) ), __METHOD__ );
 
 		$requested_order_id = sanitize_text_field( $_GET['order_number'] );
@@ -238,9 +241,14 @@ class Monri_WC_Gateway_Adapter_Webpay_Form {
 		}
 
 		$response_code = ! empty( $_GET['response_code'] ) ? sanitize_text_field( $_GET['response_code'] ) : '';
-
+        $transaction_type = $order->get_meta('transaction_type');
 		if ( $response_code === '0000' ) {
-			$order->payment_complete();
+            if ( $transaction_type === 'purchase') {
+                $order->payment_complete();
+            }
+            else {
+                $order->update_status('on-hold', __('Order awaiting payment', 'monri'));
+            }
 
 			$approval_code = ! empty( $_GET['approval_code'] ) ? sanitize_text_field( $_GET['approval_code'] ) : '';
 			if ($approval_code) {
@@ -258,6 +266,8 @@ class Monri_WC_Gateway_Adapter_Webpay_Form {
 			}
 
 			WC()->cart->empty_cart();
+            $order->update_meta_data( 'monri_order_number', sanitize_key( $_GET['order_number'] ) );
+            $order->save();
 
 		} else {
 			$order->update_status( 'failed', "Response not authorized - response code is $response_code." );
@@ -265,4 +275,138 @@ class Monri_WC_Gateway_Adapter_Webpay_Form {
 		}
 
 	}
+
+    /**
+     * Process a refund
+     *
+     * @param int $order_id
+     * @param float $amount
+     * @param string $reason
+     *
+     * @return bool
+     */
+    public function process_refund( $order_id, $amount = null) {
+
+        $order = wc_get_order( $order_id );
+        $monri_order_id = $order->get_meta( 'monri_order_number' );
+        $currency = $order->get_currency();
+
+        if ( empty( $monri_order_id ) ) {
+            $order->add_order_note( sprintf( __( 'There was an error submitting the refund to Monri.', 'monri' ) ) );
+            return false;
+        }
+
+        $response = Monri_WC_Api::instance()->refund($monri_order_id, $amount * 100, $currency);
+
+        if ( is_wp_error($response) ) {
+            $order->add_order_note( sprintf( __( 'There was an error submitting the refund to Monri.', 'monri' ) ) );
+            return false;
+        }
+        $order->update_meta_data('should_close_parent_transaction', '1');
+        $order->save();
+        $order->add_order_note(sprintf(
+            __( 'Refund of %s successfully sent to Monri.', 'monri' ),
+            wc_price( $amount, array( 'currency' => $currency ) )
+        ) );
+        return true;
+    }
+
+    /**
+     * Can the order be refunded
+     *
+     * @param  WC_Order $order
+     * @return bool
+     */
+    public function can_refund_order( $order ) {
+        return $order && in_array( $order->get_status(), wc_get_is_paid_statuses() ) &&
+            !$order->get_meta( 'should_close_parent_transaction' );
+    }
+
+    /**
+     * Capture order on Monri side
+     *
+     * @param int $order_id
+     * @param string $from
+     * @param string $to
+     * @return bool
+     */
+    public function process_capture( $order_id, $from, $to ) {
+
+        if ( ! ( in_array( $from, [ 'pending', 'on-hold' ] ) && in_array( $to, wc_get_is_paid_statuses() ) ) ) {
+            return false;
+        }
+        $order = wc_get_order( $order_id );
+        $monri_order_id = $order->get_meta( 'monri_order_number' );
+        if ( empty( $monri_order_id ) ) {
+            return false;
+        }
+        $currency = $order->get_currency();
+        $amount = $order->get_total() - $order->get_total_refunded();
+
+        if ($amount < 0.01) {
+            return false;
+        }
+
+        $response = Monri_WC_Api::instance()->capture($monri_order_id, $amount * 100, $currency);
+
+        if ( is_wp_error($response) ) {
+            $order->add_order_note(
+                sprintf( __( 'There was an error submitting the capture to Monri.', 'monri' ) ) .
+                ' ' .
+                $response->get_error_message()
+            );
+            return false;
+        }
+
+        $order->payment_complete( $monri_order_id );
+        $order->add_order_note(sprintf(
+            __( 'Capture of %s successfully sent to Monri.', 'monri' ),
+            wc_price( $amount, array( 'currency' => $order->get_currency() ) )
+        ) );
+
+        return true;
+    }
+
+    /**
+     * Void order on Monri side
+     *
+     * @param $order_id
+     * @param string $from
+     * @param string $to
+     * @return bool
+     */
+    public function process_void( $order_id, $from, $to ) {
+
+        if ( ! ( in_array( $from, [ 'pending', 'on-hold' ] ) && in_array( $to, [ 'cancelled', 'failed' ] ) ) ) {
+            return false;
+        }
+
+        $order = wc_get_order( $order_id );
+        $monri_order_id = $order->get_meta( 'monri_order_number' );
+        if ( empty( $monri_order_id ) ) {
+            return false;
+        }
+        $amount = $order->get_total() - $order->get_total_refunded();
+        $currency = $order->get_currency();
+        if ($amount < 0.01) {
+            return false;
+        }
+
+        $response = Monri_WC_Api::instance()->void($monri_order_id, $amount * 100, $currency);
+
+        if ( is_wp_error($response) ) {
+            $order->add_order_note(
+                sprintf( __( 'There was an error submitting the void to Monri.', 'monri' ) ) .
+                ' ' .
+                $response->get_error_message()
+            );
+            return false;
+        }
+
+        $order->add_order_note(sprintf(
+            __( 'Void of %s successfully sent to Monri.', 'monri' ),
+            wc_price( $amount, array( 'currency' => $order->get_currency() ) )
+        ) );
+        return true;
+    }
 }

--- a/includes/gateway.php
+++ b/includes/gateway.php
@@ -22,14 +22,17 @@ class Monri_WC_Gateway extends WC_Payment_Gateway {
 		// resolve adapter based on settings
 		if ($this->get_option('monri_payment_gateway_service') === 'monri-ws-pay') {
 			require_once __DIR__ . '/gateway-adapter-wspay.php';
+            // @todo: separate api.php into monri-api.php and wspay-api.php or use api.php for both?
 			$this->adapter = new Monri_WC_Gateway_Adapter_Wspay();
 		} elseif ($this->get_option('monri_payment_gateway_service') === 'monri-web-pay' &&
 		          $this->get_option('monri_web_pay_integration_type') === 'components'
 		) {
 			require_once __DIR__ . '/gateway-adapter-webpay-components.php';
+            require_once __DIR__ . '/monri-api.php';
 			$this->adapter = new Monri_WC_Gateway_Adapter_Webpay_Components();
 		} else {
 			require_once __DIR__ . '/gateway-adapter-webpay-form.php';
+            require_once __DIR__ . '/monri-api.php';
 			$this->adapter = new Monri_WC_Gateway_Adapter_Webpay_Form();
 		}
 
@@ -40,7 +43,7 @@ class Monri_WC_Gateway extends WC_Payment_Gateway {
         $callback = new Monri_WC_Callback();
         $callback->init();
 		//
-
+        $this->supports = [ 'products', 'refunds', 'tokenization' ];
 		if (is_admin()) {
 			add_action('woocommerce_update_options_payment_gateways_' . $this->id, [$this, 'process_admin_options']);
 		}
@@ -140,5 +143,17 @@ class Monri_WC_Gateway extends WC_Payment_Gateway {
 	public function get_option_bool( $key ) {
 		return in_array( $this->get_option( $key ),  array( 'yes', '1', true ), true );
 	}
+
+    /**
+     * Forward to adapter
+     *
+     * @inheritDoc
+     */
+    public function can_refund_order( $order ) {
+        if(method_exists($this->adapter, 'can_refund_order')) {
+            return $this->adapter->can_refund_order( $order);
+        }
+        return parent::can_refund_order( $order);
+    }
 
 }

--- a/monri.php
+++ b/monri.php
@@ -8,7 +8,7 @@ Author URI: https://monri.com
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 WC requires at least: 4.3.0
-WC tested up to: 8.7
+WC tested up to: 9.0.2
 */
 if ( ! defined( 'ABSPATH' ) ) exit;
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: monripayments
 Tags: monri, credit card, payment, woocommerce
 Requires at least: 5.3
-Tested up to: 6.4.2
+Tested up to: 6.6
 Requires PHP: 7.3
 Stable tag: 3.1.1
 License: GPLv3


### PR DESCRIPTION
Several new features for new release

- Capture, refund, void APIs implemented for all payment methods (Monri form, components and Wspay)
- Monri orders can be refunded, captured, voided from administration
- Componsts initialization caching to avoid unneeded initializations
- tested on latest Woocommerce and upcomming WP 6.6
- mulstiple fixes and improvements